### PR TITLE
Add IPv4/IPv6 filtering support

### DIFF
--- a/cmd/fwprobe/main.go
+++ b/cmd/fwprobe/main.go
@@ -62,6 +62,8 @@ var (
 	noColor     bool
 	exitCode    bool
 	quiet       bool
+	ipv4Only    bool
+	ipv6Only    bool
 )
 
 func init() {
@@ -78,12 +80,20 @@ func init() {
 	runCmd.Flags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	runCmd.Flags().BoolVar(&exitCode, "exit-code", true, "Exit with code 1 if any test fails")
 	runCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only print failures and summary")
+	runCmd.Flags().BoolVar(&ipv4Only, "ipv4-only", false, "Test only IPv4 addresses")
+	runCmd.Flags().BoolVar(&ipv6Only, "ipv6-only", false, "Test only IPv6 addresses")
 
 	// Validate command flags
 	validateCmd.Flags().StringVarP(&configFile, "config", "c", "fwprobe.yaml", "Path to config file")
 }
 
 func runTests(cmd *cobra.Command, args []string) error {
+	// Validate flags
+	if ipv4Only && ipv6Only {
+		fmt.Fprintf(os.Stderr, "Error: Cannot specify both --ipv4-only and --ipv6-only\n")
+		return exitWithCode(2)
+	}
+
 	// Load configuration
 	cfg, err := config.Load(configFile)
 	if err != nil {
@@ -91,8 +101,16 @@ func runTests(cmd *cobra.Command, args []string) error {
 		return exitWithCode(2)
 	}
 
+	// Determine IP filter mode
+	ipFilter := runner.IPFilterBoth
+	if ipv4Only {
+		ipFilter = runner.IPFilterIPv4Only
+	} else if ipv6Only {
+		ipFilter = runner.IPFilterIPv6Only
+	}
+
 	// Create runner
-	r := runner.New(cfg, concurrency, failFast, filter)
+	r := runner.New(cfg, concurrency, failFast, filter, ipFilter)
 
 	// Execute tests
 	ctx := context.Background()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -11,6 +12,18 @@ import (
 	"github.com/mcyrrer/mcfwtest/internal/config"
 	"github.com/mcyrrer/mcfwtest/internal/network"
 	"github.com/mcyrrer/mcfwtest/internal/probe"
+)
+
+// IPFilter represents IP version filtering mode
+type IPFilter int
+
+const (
+	// IPFilterBoth allows both IPv4 and IPv6 addresses
+	IPFilterBoth IPFilter = iota
+	// IPFilterIPv4Only filters to only IPv4 addresses
+	IPFilterIPv4Only
+	// IPFilterIPv6Only filters to only IPv6 addresses
+	IPFilterIPv6Only
 )
 
 // TestCase represents a single test to be executed
@@ -47,16 +60,18 @@ type Runner struct {
 	Concurrency int
 	FailFast    bool
 	Filter      string
+	IPFilter    IPFilter
 	Prober      probe.Prober
 }
 
 // New creates a new Runner
-func New(cfg *config.Config, concurrency int, failFast bool, filter string) *Runner {
+func New(cfg *config.Config, concurrency int, failFast bool, filter string, ipFilter IPFilter) *Runner {
 	return &Runner{
 		Config:      cfg,
 		Concurrency: concurrency,
 		FailFast:    failFast,
 		Filter:      filter,
+		IPFilter:    ipFilter,
 		Prober:      probe.NewTCPProber(),
 	}
 }
@@ -173,7 +188,37 @@ func (r *Runner) expandHosts(ep config.Endpoint) ([]string, error) {
 		}
 	}
 
+	// Apply IP version filtering
+	if r.IPFilter != IPFilterBoth {
+		hosts = r.filterIPsByVersion(hosts)
+	}
+
 	return hosts, nil
+}
+
+// filterIPsByVersion filters IP addresses based on the configured IP version filter
+func (r *Runner) filterIPsByVersion(ips []string) []string {
+	var filtered []string
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			continue
+		}
+
+		isIPv4 := parsedIP.To4() != nil
+
+		switch r.IPFilter {
+		case IPFilterIPv4Only:
+			if isIPv4 {
+				filtered = append(filtered, ip)
+			}
+		case IPFilterIPv6Only:
+			if !isIPv4 {
+				filtered = append(filtered, ip)
+			}
+		}
+	}
+	return filtered
 }
 
 // expandPorts expands the port/ports field


### PR DESCRIPTION
### **User description**
$(cat <<'EOF'
## Summary
- Implements issue #3
- Adds support for filtering tests to only IPv4 or IPv6 addresses
- Provides `--ipv4-only` and `--ipv6-only` command-line switches

## Changes
- Added `IPFilter` type and constants to runner package
- Modified `Runner.New()` to accept IP filter parameter
- Updated `expandHosts()` to apply IP version filtering after DNS resolution
- Added `filterIPsByVersion()` helper function using `net.ParseIP()`
- Added validation to prevent using both flags simultaneously

## Usage
```bash
# Test only IPv4 addresses
fwprobe run --config fwprobe.yaml --ipv4-only

# Test only IPv6 addresses
fwprobe run --config fwprobe.yaml --ipv6-only

# Error: cannot use both
fwprobe run --config fwprobe.yaml --ipv4-only --ipv6-only
```

## Test plan
- [x] Built and tested with dual-stack hostname (google.com)
- [x] Verified --ipv4-only filters to IPv4 addresses only
- [x] Verified --ipv6-only filters to IPv6 addresses only
- [x] Verified mutual exclusivity validation works
- [x] Tested that filtering works after DNS resolution
- [x] Without flags: 5 tests (1 IPv4 + 4 IPv6)
- [x] With --ipv4-only: 1 test (IPv4 only)
- [x] With --ipv6-only: 4 tests (IPv6 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `--ipv4-only` and `--ipv6-only` command-line flags for IP version filtering

- Implements `IPFilter` type with three modes: both, IPv4-only, IPv6-only

- Filters IP addresses after DNS resolution using `net.ParseIP()`

- Validates mutual exclusivity of both flags to prevent conflicting usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Flags<br/>--ipv4-only<br/>--ipv6-only"] --> B["Flag Validation<br/>Mutual Exclusivity"]
  B --> C["IPFilter Mode<br/>Selection"]
  C --> D["Runner Creation<br/>with IPFilter"]
  D --> E["expandHosts<br/>DNS Resolution"]
  E --> F["filterIPsByVersion<br/>Apply Filter"]
  F --> G["Filtered IP List"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add CLI flags and validation for IP filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/fwprobe/main.go

<ul><li>Added <code>ipv4Only</code> and <code>ipv6Only</code> boolean flag variables<br> <li> Registered <code>--ipv4-only</code> and <code>--ipv6-only</code> command-line flags in <code>init()</code><br> <li> Added validation in <code>runTests()</code> to prevent using both flags <br>simultaneously<br> <li> Determined <code>IPFilter</code> mode based on flag values and passed it to <br><code>runner.New()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mcyrrer/mcfwtest/pull/6/files#diff-1c156ca77e6385e7a8de593b8eea8fd80710e0e4ecb7a4872c57c750c41c1627">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runner.go</strong><dd><code>Implement IP version filtering logic in runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/runner/runner.go

<ul><li>Defined <code>IPFilter</code> type and three constants: <code>IPFilterBoth</code>, <br><code>IPFilterIPv4Only</code>, <code>IPFilterIPv6Only</code><br> <li> Added <code>IPFilter</code> field to <code>Runner</code> struct<br> <li> Updated <code>New()</code> constructor to accept <code>ipFilter</code> parameter<br> <li> Added <code>filterIPsByVersion()</code> method that uses <code>net.ParseIP()</code> to identify <br>IPv4 vs IPv6<br> <li> Integrated filtering into <code>expandHosts()</code> to apply filter after DNS <br>resolution<br> <li> Imported <code>net</code> package for IP parsing functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/mcyrrer/mcfwtest/pull/6/files#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6">+46/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

