### PR TITLE
Fix graceful handling of DNS resolution failures

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -28,12 +28,13 @@ const (
 
 // TestCase represents a single test to be executed
 type TestCase struct {
-	EndpointName string
-	Host         string
-	Port         int
-	Protocol     string
-	Timeout      time.Duration
-	Expect       string
+	EndpointName   string
+	Host           string
+	Port           int
+	Protocol       string
+	Timeout        time.Duration
+	Expect         string
+	ExpansionError error // DNS or CIDR expansion error, if any
 }
 
 // TestResult represents the result of a single test execution
@@ -115,14 +116,40 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // expandTestCases expands endpoint configurations into individual test cases
+// DNS resolution errors are handled gracefully by creating error test cases
 func (r *Runner) expandTestCases() ([]TestCase, error) {
 	var testCases []TestCase
+	var errors []expansionError
 
 	for _, ep := range r.Config.Endpoints {
 		// Expand hosts
 		hosts, err := r.expandHosts(ep)
 		if err != nil {
-			return nil, fmt.Errorf("endpoint %q: %w", ep.Name, err)
+			// Instead of failing immediately, track the error and create an error test case
+			errors = append(errors, expansionError{
+				endpointName: ep.Name,
+				err:          err,
+			})
+
+			// Create a placeholder test case that will report the error
+			// Use the first port if available, otherwise use 0 as placeholder
+			port := 0
+			if ep.Port != 0 {
+				port = ep.Port
+			} else if len(ep.Ports) > 0 {
+				port = ep.Ports[0]
+			}
+
+			testCases = append(testCases, TestCase{
+				EndpointName:    ep.Name,
+				Host:            ep.Host, // Use the original host that failed
+				Port:            port,
+				Protocol:        ep.Protocol,
+				Timeout:         ep.Timeout.Duration,
+				Expect:          ep.Expect,
+				ExpansionError:  err, // Store the error for later reporting
+			})
+			continue
 		}
 
 		// Expand ports
@@ -144,6 +171,12 @@ func (r *Runner) expandTestCases() ([]TestCase, error) {
 	}
 
 	return testCases, nil
+}
+
+// expansionError tracks errors during test case expansion
+type expansionError struct {
+	endpointName string
+	err          error
 }
 
 // expandHosts expands the host/hosts field, handling CIDR ranges and DNS resolution
@@ -322,6 +355,14 @@ func (r *Runner) executeTests(ctx context.Context, testCases []TestCase) []TestR
 
 // executeTestCase executes a single test case
 func (r *Runner) executeTestCase(ctx context.Context, tc TestCase) TestResult {
+	// Check if there was an expansion error (DNS resolution, CIDR expansion, etc.)
+	if tc.ExpansionError != nil {
+		return TestResult{
+			TestCase: tc,
+			Error:    tc.ExpansionError,
+		}
+	}
+
 	// Select the appropriate prober based on protocol
 	var prober probe.Prober
 	switch tc.Protocol {


### PR DESCRIPTION
### **User description**
$(cat <<'EOF'
## Summary
Fixes #8 - DNS resolution errors no longer cause the entire test run to fail. Instead, they are handled gracefully and reported as errors while allowing other tests to continue.

## Problem
Previously, when a hostname couldn't be resolved (e.g., `internal-server.local`), the entire test run would fail immediately with:
```
Error: Failed to run tests: endpoint "blocked-service": failed to resolve hostname "internal-server.local": lookup internal-server.local: no such host
```

## Solution
Modified the test expansion logic to:
1. Catch DNS/CIDR expansion errors during test case creation
2. Create placeholder test cases for failed expansions
3. Report expansion errors as test errors (not failures)
4. Continue executing other valid tests

## Changes

### Code Changes
- **Modified `expandTestCases()`**: Now catches errors and creates error test cases
- **Added `ExpansionError` field**: TestCase struct tracks expansion errors
- **Updated `executeTestCase()`**: Checks for expansion errors before probing
- **Added `expansionError` type**: Internal tracking of expansion failures

### Behavior Changes
- ✅ DNS lookup failures are shown as ERROR status
- ✅ All valid tests continue to execute
- ✅ Clear error messages indicate resolution failures
- ✅ Exit code 1 when errors occur (unchanged behavior)

## Example Output

**Before (failed completely):**
```
Error: Failed to run tests: endpoint "blocked-service": failed to resolve hostname...
```

**After (continues gracefully):**
```
╭─────────────────────────────────╮
│ FWProbe — Firewall Rule Testing │
│ Tests: 4 | Concurrency: N/A     │
╰─────────────────────────────────╯

  non-existent-host
    ✘ this-host-does-not-exist.invalid:80/tcp ··· failed to resolve hostname ERROR

  google-dns
    ✔ 8.8.8.8:53/tcp ··· open (30ms) PASS

  localhost
    ✔ 127.0.0.1:22/tcp ··· closed (0ms) PASS

────────────────────────────────────────────────────────────
  Results: 2 passed · 0 failed · 1 error · 3 total
  Duration: 31ms
────────────────────────────────────────────────────────────
```

## Testing

Tested with configuration containing:
- ✅ Non-existent DNS names (properly handled as errors)
- ✅ Valid IP addresses (continued to work)
- ✅ Mix of failing and passing tests (all executed)
- ✅ Multiple DNS errors in same run (all handled)

## Impact
- **Users**: Can now run tests even when some hostnames can't be resolved
- **CI/CD**: Partial test failures don't block entire test suite
- **Debugging**: Clear visibility into which hostnames failed resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)


___

### **PR Type**
Bug fix


___

### **Description**
- Handle DNS resolution failures gracefully without stopping test execution

- Add `ExpansionError` field to `TestCase` struct for tracking expansion errors

- Create placeholder test cases for failed hostname resolutions

- Check for expansion errors in `executeTestCase()` before probing

- Report DNS errors as ERROR status in test results instead of failing entire run


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["expandTestCases()"] -->|DNS error occurs| B["Create expansionError"]
  B --> C["Create placeholder TestCase"]
  C -->|with ExpansionError field| D["executeTestCase()"]
  D -->|Check ExpansionError| E["Return ERROR result"]
  E --> F["Continue other tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runner.go</strong><dd><code>Graceful DNS error handling with placeholder test cases</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/runner/runner.go

<ul><li>Added <code>ExpansionError</code> field to <code>TestCase</code> struct to track DNS/CIDR <br>expansion errors<br> <li> Modified <code>expandTestCases()</code> to catch expansion errors and create <br>placeholder test cases instead of returning immediately<br> <li> Added internal <code>expansionError</code> struct for tracking expansion failures <br>with endpoint name and error details<br> <li> Updated <code>executeTestCase()</code> to check for expansion errors before <br>executing probes and return ERROR result if present<br> <li> Reformatted <code>TestCase</code> struct field alignment for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/mcyrrer/mcfwtest/pull/9/files#diff-ddc7e46dbd3f77cb194815142eb06ccf62e24963d16039f1ff41266e4ec3d7a6">+48/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

